### PR TITLE
League of Legends shop in game fix

### DIFF
--- a/dlls/wined3d/resource.c
+++ b/dlls/wined3d/resource.c
@@ -220,7 +220,10 @@ BOOL wined3d_resource_allocate_sysmem(struct wined3d_resource *resource)
     SIZE_T align = RESOURCE_ALIGNMENT - 1 + sizeof(*p);
     void *mem;
 
-    if (!(mem = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, resource->size + align)))
+    UINT size = resource->size;
+    if (resource->width <= 128 && resource->height <= 128)
+    size *= 2;
+    if (!(mem = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, size + align)))
         return FALSE;
 
     p = (void **)(((ULONG_PTR)mem + align) & ~(RESOURCE_ALIGNMENT - 1)) - 1;


### PR DESCRIPTION
This doubles the allocated memory of textures lower than 128×128 pixels of size, and fixes the shop crash while leaving the icons visible