### PR TITLE
DRI3Present: fix compilation on latest upstream Mesa

### DIFF
--- a/dlls/winex11.drv/d3dadapter.c
+++ b/dlls/winex11.drv/d3dadapter.c
@@ -96,9 +96,9 @@ struct d3d_wnd_hooks
 
 static HRESULT dri3_present_unregister_window_hook( struct DRI3Present *This );
 static HRESULT dri3_present_register_window_hook( struct DRI3Present *This );
-#endif
 
 static struct d3d_wnd_hooks d3d_hooks;
+#endif
 
 struct DRI3Present
 {


### PR DESCRIPTION
Some games are minimized on startup as they would lose focus, for example:
Guild Wars 2, Battlefield: Bad Company 2, ...
Active the draw window less intrusive and allow to start fullscreen.

Signed-off-by: Patrick Rudolph <siro@das-labor.org>