### PR TITLE
winex11.drv/d3dadapter: fix possible null pointer dereference

### DIFF
--- a/dlls/winex11.drv/d3dadapter.c
+++ b/dlls/winex11.drv/d3dadapter.c
@@ -871,7 +871,8 @@ DRI3PresentGroup_Release( struct DRI3PresentGroup *This )
         unsigned i;
         if (This->present_backends) {
             for (i = 0; i < This->npresent_backends; ++i) {
-                DRI3Present_Release(This->present_backends[i]);
+                if (This->present_backends[i])
+                    DRI3Present_Release(This->present_backends[i]);
             }
             HeapFree(GetProcessHeap(), 0, This->present_backends);
         }


### PR DESCRIPTION
In case that dri3_create_present_group takes the error path, there'd be no
present backends to destroy.

Signed-off-by: Patrick Rudolph <siro@das-labor.org>